### PR TITLE
New page to collect links for all training materials

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -52,6 +52,7 @@ A comprehensive list of Web site content:
    members
    grants
    reading-guide
+   training
    contact
    press
    affiliations

--- a/training.rst
+++ b/training.rst
@@ -34,3 +34,13 @@ from our training workshops are posted `here <http://dib-training.readthedocs.io
 Titus coordinated the Analysis of Next Generation Sequencing (ANGUS) workshop from 2010 to 2016 at Michigan State University's Kellogg Biological Station in Kalamazoo, MI. Materials from the most recent workshop in 2016 are `here <http://angus.readthedocs.io/en/2016/>`__. 
 
 There will be a Data Intensive Biology Summer Institute (DIBSI) held at UC Davis this year from June 18 to July 21, 2017. Applications for DIBSI are due by March 17, 2017. The website with more information on what material is covered and instructions for how to apply is `here <http://ivory.idyll.org/dibsi/index.html>`__. 
+
+Misc. Tutorials
+---------------
+
+- `screed <https://github.com/dib-lab/2016-illo-screed>`__
+- `sourmash <https://github.com/dib-lab/2016-illo-sourmash>`__(`YouTube recording <https://www.youtube.com/watch?v=VZ6wBW1PGIk>`__)
+- `binder <https://github.com/ctb/2016-illo-binder>`__ (`YouTube recording <https://www.youtube.com/watch?v=uScICXDIJvU>`__)
+- `Zen and the Art of Kmers (using khmer) <https://dib-lab.github.io/zen-khmer/>`__ (June 13-15, 2016)
+
+

--- a/training.rst
+++ b/training.rst
@@ -30,3 +30,7 @@ Workshops
 
 The lab does quite a bit of training. Materials (and often live-streamd videos!)
 from our training workshops are posted `here <http://dib-training.readthedocs.io/>`__.
+
+Titus coordinated the Analysis of Next Generation Sequencing (ANGUS) workshop from 2010 to 2016 at Michigan State University's Kellogg Biological Station in Kalamazoo, MI. Materials from the most recent workshop in 2016 are `here <http://angus.readthedocs.io/en/2016/>`__. 
+
+There will be a Data Intensive Biology Summer Institute (DIBSI) held at UC Davis this year from June 18 to July 21, 2017. Applications for DIBSI are due by March 17, 2017. The website with more information on what material is covered and instructions for how to apply is `here <http://ivory.idyll.org/dibsi/index.html>`__. 

--- a/training.rst
+++ b/training.rst
@@ -37,7 +37,7 @@ There will be a Data Intensive Biology Summer Institute (DIBSI) held at UC Davis
 
 Misc. Tutorials
 ---------------
-
+- `NGS 2015 week 3 <http://angus.readthedocs.io/en/2015/week3.html>`__
 - `screed <https://github.com/dib-lab/2016-illo-screed>`__
 - `sourmash <https://github.com/dib-lab/2016-illo-sourmash>`__ (`YouTube recording <https://www.youtube.com/watch?v=VZ6wBW1PGIk>`__)
 - `binder <https://github.com/ctb/2016-illo-binder>`__ (`YouTube recording <https://www.youtube.com/watch?v=uScICXDIJvU>`__)

--- a/training.rst
+++ b/training.rst
@@ -1,0 +1,32 @@
+Training materials
+==================
+
+Eel Pond Protocol
+-----------------
+
+The Eel Pond protocol covers common mRNA analyses, including assembly, quality
+assessment, annotation, quantification, and differential expression.
+
+- Legacy protocol
+    - `site <http://khmer-protocols.readthedocs.io/en/v0.8.4/mrnaseq/index.html>`__
+    - `code <https://github.com/dib-lab/khmer-protocols/tree/master/mrnaseq>`__
+- New protocol (still under development)
+    - `site <http://eel-pond.readthedocs.io>`__
+    - `code <https://github.com/dib-lab/eel-pond/>`__
+
+
+Kalamazoo Protocol
+------------------
+
+The Kalamazoo protocol covers common metagenomic analyses, including assembly,
+quantification, and annotation.
+
+- `site <http://khmer-protocols.readthedocs.io/en/v0.8.4/metagenomics/index.html>`__
+- `code <https://github.com/dib-lab/khmer-protocols/tree/master/metagenomics>`__
+
+
+Workshops
+---------
+
+The lab does quite a bit of training. Materials (and often live-streamd videos!)
+from our training workshops are posted `here <http://dib-training.readthedocs.io/>`__.

--- a/training.rst
+++ b/training.rst
@@ -39,7 +39,7 @@ Misc. Tutorials
 ---------------
 
 - `screed <https://github.com/dib-lab/2016-illo-screed>`__
-- `sourmash <https://github.com/dib-lab/2016-illo-sourmash>`__(`YouTube recording <https://www.youtube.com/watch?v=VZ6wBW1PGIk>`__)
+- `sourmash <https://github.com/dib-lab/2016-illo-sourmash>`__ (`YouTube recording <https://www.youtube.com/watch?v=VZ6wBW1PGIk>`__)
 - `binder <https://github.com/ctb/2016-illo-binder>`__ (`YouTube recording <https://www.youtube.com/watch?v=uScICXDIJvU>`__)
 - `Zen and the Art of Kmers (using khmer) <https://dib-lab.github.io/zen-khmer/>`__ (June 13-15, 2016)
 


### PR DESCRIPTION
At our Yosemite retreat, one of the discussion points was that we wanted better aggregation and curation of all of the training resources the lab has scattered throughout the interwebs. This problem has manifested itself multiple times recently with people working off of different and/or outdated versions of the Eel Pond protocol.

This pull request introduces a new page on the website with links to the khmer protocols and the DIB training workshop materials and videos. This is a very small first step, with much more that could potentially be done.